### PR TITLE
Changes to allow Review Board to be served out of the site root.

### DIFF
--- a/manifests/provider/web/puppetlabsapache.pp
+++ b/manifests/provider/web/puppetlabsapache.pp
@@ -28,13 +28,19 @@ define reviewboard::provider::web::puppetlabsapache (
   include apache::mod::mime
 
   $error_documents = [{error_code => '500', document => '/errordocs/500.html'}]
-  $script_aliases  = {"${location}" => "${site}/htdocs/reviewboard.wsgi/reviewboard"}
+  if ($location == '/') {
+    $locationfragment = ''
+  } else {
+    $locationfragment = "${location}"
+  }
+
+  $script_aliases  = {"${location}" => "${site}/htdocs/reviewboard.wsgi${locationfragment}"}
 
   $directories = [
     {path   => "${site}/htdocs",
     options => ['-Indexes','+FollowSymLinks']
     },
-    {path           => "${location}/media/uploaded",
+    {path           => "${locationfragment}/media/uploaded",
     provider        => 'location',
     custom_fragment => '
       SetHandler None
@@ -50,16 +56,16 @@ define reviewboard::provider::web::puppetlabsapache (
   ]
 
   $aliases = [
-    {alias => "${location}/media",
+    {alias => "${locationfragment}/media",
     path => "${site}/htdocs/media"
     },
-    {alias => "${location}/static",
+    {alias => "${locationfragment}/static",
     path => "${site}/htdocs/static"
     },
-    {alias => "${location}/errordocs",
+    {alias => "${locationfragment}/errordocs",
     path => "${site}/htdocs/errordocs"
     },
-    {alias => "${location}/favicon.ico",
+    {alias => "${locationfragment}/favicon.ico",
     path => "${site}/htdocs/static/rb/images/favicon.png"
     },
   ]

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -51,10 +51,15 @@ define reviewboard::site (
     dbhost => $dbhost,
   }
 
+  case $location { # A trailing slash is required
+    /\/$/:   { $normalized_location = $location}
+    default: { $normalized_location = "${location}/" }
+  }
+
   # Run site-install
   reviewboard::site::install {$site:
     vhost      => $vhost,
-    location   => "${location}/", # Trailing slash required
+    location   => $normalized_location,
     dbtype     => $dbtype,
     dbname     => $dbname,
     dbhost     => $dbhost,


### PR DESCRIPTION
This pull request has the necessary changes to fix issue #3.

I've tested it with location='/' and location='/reviewboard' and verified both work.

We may want to consider having the location default be '/' as that is the rb-site install default.
