### PR TITLE
'python-pip' must be installed before we can run pip commands.

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -21,6 +21,10 @@ class reviewboard::package {
   # Install Reviewboard 2 as that supports custom extensions
   $version = '2.0beta3'
 
+  package { 'python-pip':
+    ensure => installed,
+  }
+
   exec {'easy_install reviewboard':
     command => "easy_install http://downloads.reviewboard.org/releases/ReviewBoard/2.0/ReviewBoard-${version}-py2.6.egg",
     unless  => "pip freeze | grep 'ReviewBoard==${version}'",


### PR DESCRIPTION
Prior to this change, I'd see error like the following:

Error: Could not find dependency Package[python-pip] for Exec[easy_install reviewboard] at /root/puppet/3rd-party-modules/reviewboard/manifests/package.pp:35
