### PR TITLE
Adding puppetlabs/mysql as a possible db provider.

### DIFF
--- a/manifests/provider/db.pp
+++ b/manifests/provider/db.pp
@@ -32,6 +32,13 @@ define reviewboard::provider::db (
       dbuser => $dbuser,
       dbpass => $dbpass,
     }
+  } elsif $reviewboard::dbprovider == 'puppetlabs/mysql' {
+    reviewboard::provider::db::puppetlabsmysql {$site:
+      dbname => $dbname,
+      dbhost => $dbhost,
+      dbuser => $dbuser,
+      dbpass => $dbpass,
+    }
   } elsif $reviewboard::dbprovider == 'none' {
     # No-op
   } else {

--- a/manifests/provider/db/puppetlabsmysql.pp
+++ b/manifests/provider/db/puppetlabsmysql.pp
@@ -1,0 +1,45 @@
+## \file    manifests/provider/db/puppetlabsmysql.pp
+#  \author  Scott Wales <scott.wales@unimelb.edu.au>
+#  \brief
+#
+#  Copyright 2014 Scott Wales
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Sets up the site DB using puppetlabs/mysql
+define reviewboard::provider::db::puppetlabsmysql (
+  $dbuser,
+  $dbpass,
+  $dbname,
+  $dbhost = 'localhost',
+) {
+
+  if $dbhost != 'localhost' {
+    err('Remote db hosts not implemented')
+  }
+
+  class { '::mysql::bindings':
+    python_enable => true,
+  }
+
+  class { '::mysql::server':
+    root_password    => $dbpass,
+  }
+
+  ::mysql::db { $dbname:
+    user      => $dbuser,
+    password  => $dbpass,
+    host      => $dbhost,
+  }
+
+}


### PR DESCRIPTION
Starting the conversation about adding a mysql provider.

I'll probably want to add docs to this pull request before merging, but perhaps other stuff is needed as well.

My only testing thus far has been by hand with puppetlabs/mysql  v2.2.3 and CentOS 6.5.
