### PR TITLE
Move the default version from reviewboard::package to reviewboard.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You can change how the sites are configured with the 'provider' arguments to the
 The default settings are
     
     class reviewboard {
-        version     => '1.7.22',
+        version     => '1.7.24',
         webprovider => 'puppetlabs/apache',
         dbprovider  => 'puppetlabs/postgresql'
     }

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Create a reviewboard site based at '/var/www/reviewboard', available at ${::fqdn
         location => '/reviewboard'
     }
 
+You can change the review board version installed with the 'version' argument to the
+reviewboard class. Acceptable values for the version argument look like '1.7.20' or
+'2.0rc1'. You can find a catalog of versions at:
+
+http://downloads.reviewboard.org/releases/ReviewBoard/.
+
 You can change how the sites are configured with the 'provider' arguments to the reviewboard class. 
 
 **webprovider**:
@@ -51,6 +57,7 @@ You can change how the sites are configured with the 'provider' arguments to the
 The default settings are
     
     class reviewboard {
+        version     => '1.7.22',
         webprovider => 'puppetlabs/apache',
         dbprovider  => 'puppetlabs/postgresql'
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,12 +26,15 @@
 # dbtype:      Type of database to use
 
 class reviewboard (
+  $version     = '1.7.22', # Current stable release
   $webprovider = 'puppetlabs/apache',
   $webuser     = undef,
   $dbprovider  = 'puppetlabs/postgresql',
   $dbtype      = 'postgresql'
 ) {
 
-  include reviewboard::package
+  class { 'reviewboard::package':
+    version => $version,
+  }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,7 +26,7 @@
 # dbtype:      Type of database to use
 
 class reviewboard (
-  $version     = '1.7.22', # Current stable release
+  $version     = '1.7.24', # Current stable release
   $webprovider = 'puppetlabs/apache',
   $webuser     = undef,
   $dbprovider  = 'puppetlabs/postgresql',

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -17,7 +17,7 @@
 #  limitations under the License.
 
 class reviewboard::package (
-  $version = '1.7.22', # the current stable release
+  $version = undef,
 ) {
   
   $base_url = "http://downloads.reviewboard.org/releases/ReviewBoard"


### PR DESCRIPTION
Move the default version from reviewboard::package to reviewboard. …
As the review board version is presently system wide, it makes
sense to have an option for it at the top level.

Other small versioning changes wrapped into this pull request as well.
