### PR TITLE
Puppet lint fixes

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -19,12 +19,14 @@
 class reviewboard::package (
   $version = '1.7.22', # the current stable release
 ) {
-  
-  $base_url = "http://downloads.reviewboard.org/releases/ReviewBoard"
+
+  $base_url = 'http://downloads.reviewboard.org/releases/ReviewBoard'
   case $version {
     /^2\.0\./: { $egg_url = "${base_url}/2.0/ReviewBoard-${version}-py2.6.egg" }
     /^1\.7\./: { $egg_url = "${base_url}/1.7/ReviewBoard-${version}-py2.6.egg" }
-    default: { fail("Review Board ${version} has not been tested with reviewboard::package.") }
+    default: {
+      fail("Review Board ${version} has not been tested with reviewboard::package.")
+    }
   }
 
   exec {'easy_install reviewboard':

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -25,7 +25,7 @@ class reviewboard::package (
     /^2\.0\./: { $egg_url = "${base_url}/2.0/ReviewBoard-${version}-py2.6.egg" }
     /^1\.7\./: { $egg_url = "${base_url}/1.7/ReviewBoard-${version}-py2.6.egg" }
     default: {
-      fail("Review Board ${version} has not been tested with reviewboard::package.")
+      fail("reviewboard::package has not been tested with Review Board ${version}.")
     }
   }
 

--- a/manifests/provider/web/puppetlabsapache.pp
+++ b/manifests/provider/web/puppetlabsapache.pp
@@ -31,10 +31,10 @@ define reviewboard::provider::web::puppetlabsapache (
   if ($location == '/') {
     $locationfragment = ''
   } else {
-    $locationfragment = "${location}"
+    $locationfragment = $location
   }
 
-  $script_aliases  = {"${location}" => "${site}/htdocs/reviewboard.wsgi${locationfragment}"}
+  $script_aliases  = {$location => "${site}/htdocs/reviewboard.wsgi${locationfragment}"}
 
   $directories = [
     {path   => "${site}/htdocs",


### PR DESCRIPTION
Afterwards:

```
$  puppet-lint --with-filename .
./manifests/site/config.pp - WARNING: line has more than 80 characters on line 27
./manifests/site/config.pp - WARNING: line has more than 80 characters on line 28
./manifests/provider/web/puppetlabsapache.pp - WARNING: line has more than 80 characters on line 37
./manifests/package.pp - WARNING: line has more than 80 characters on line 28
$
```
